### PR TITLE
docs(launchdarkly): add examples/minimal/config.yaml

### DIFF
--- a/examples/minimal/config.yaml
+++ b/examples/minimal/config.yaml
@@ -1,0 +1,13 @@
+# Minimal config exercising workflow-plugin-launchdarkly.
+# Schema-validate with: wfctl validate --skip-unknown-types examples/minimal/config.yaml
+version: 1
+modules:
+  - name: launchdarkly-provider
+    type: launchdarkly.provider
+    config: {}
+workflows:
+  pipeline:
+    steps:
+      - name: example
+        type: step.ld_flag_create
+        config: {}


### PR DESCRIPTION
Closes the P2-tier examples gap from workflow#714.