### PR TITLE
chore: advertise required_secrets[] (LAUNCHDARKLY_API_KEY)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,4236 +1,4244 @@
 {
-    "name": "workflow-plugin-launchdarkly",
-    "version": "0.1.1",
-    "description": "LaunchDarkly feature management plugin",
-    "author": "GoCodeAlone",
-    "license": "MIT",
-    "type": "external",
-    "tier": "community",
-    "private": false,
-    "minEngineVersion": "0.51.7",
-    "keywords": [
-        "launchdarkly",
-        "feature-flags",
-        "feature-management"
+  "name": "workflow-plugin-launchdarkly",
+  "version": "0.1.1",
+  "description": "LaunchDarkly feature management plugin",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "LAUNCHDARKLY_API_KEY",
+      "sensitive": true,
+      "description": "LaunchDarkly REST API (management) key. Referenced as ${LAUNCHDARKLY_API_KEY} in apiKey.",
+      "prompt": "LaunchDarkly API key"
+    }
+  ],
+  "keywords": [
+    "launchdarkly",
+    "feature-flags",
+    "feature-management"
+  ],
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly",
+  "capabilities": {
+    "configProvider": false,
+    "moduleTypes": [
+      "launchdarkly.provider"
     ],
-    "homepage": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly",
-    "repository": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly",
-    "capabilities": {
-        "configProvider": false,
-        "moduleTypes": [
-            "launchdarkly.provider"
-        ],
-        "stepTypes": [
-            "step.launchdarkly_flag_list",
-            "step.launchdarkly_flag_get",
-            "step.launchdarkly_flag_create",
-            "step.launchdarkly_flag_update",
-            "step.launchdarkly_flag_delete",
-            "step.launchdarkly_flag_copy",
-            "step.launchdarkly_flag_status_get",
-            "step.launchdarkly_flag_status_list",
-            "step.launchdarkly_project_list",
-            "step.launchdarkly_project_get",
-            "step.launchdarkly_project_create",
-            "step.launchdarkly_project_update",
-            "step.launchdarkly_project_delete",
-            "step.launchdarkly_environment_list",
-            "step.launchdarkly_environment_get",
-            "step.launchdarkly_environment_create",
-            "step.launchdarkly_environment_update",
-            "step.launchdarkly_environment_delete",
-            "step.launchdarkly_environment_reset_sdk_key",
-            "step.launchdarkly_environment_reset_mobile_key",
-            "step.launchdarkly_segment_list",
-            "step.launchdarkly_segment_get",
-            "step.launchdarkly_segment_create",
-            "step.launchdarkly_segment_update",
-            "step.launchdarkly_segment_delete",
-            "step.launchdarkly_context_list",
-            "step.launchdarkly_context_get",
-            "step.launchdarkly_context_search",
-            "step.launchdarkly_context_kind_list",
-            "step.launchdarkly_context_kind_upsert",
-            "step.launchdarkly_context_evaluate",
-            "step.launchdarkly_metric_list",
-            "step.launchdarkly_metric_get",
-            "step.launchdarkly_metric_create",
-            "step.launchdarkly_metric_update",
-            "step.launchdarkly_metric_delete",
-            "step.launchdarkly_experiment_list",
-            "step.launchdarkly_experiment_get",
-            "step.launchdarkly_experiment_create",
-            "step.launchdarkly_experiment_update",
-            "step.launchdarkly_experiment_results_get",
-            "step.launchdarkly_approval_list",
-            "step.launchdarkly_approval_get",
-            "step.launchdarkly_approval_create",
-            "step.launchdarkly_approval_delete",
-            "step.launchdarkly_approval_apply",
-            "step.launchdarkly_approval_review",
-            "step.launchdarkly_scheduled_change_list",
-            "step.launchdarkly_scheduled_change_create",
-            "step.launchdarkly_scheduled_change_update",
-            "step.launchdarkly_scheduled_change_delete",
-            "step.launchdarkly_trigger_list",
-            "step.launchdarkly_trigger_create",
-            "step.launchdarkly_trigger_get",
-            "step.launchdarkly_trigger_update",
-            "step.launchdarkly_trigger_delete",
-            "step.launchdarkly_workflow_list",
-            "step.launchdarkly_workflow_get",
-            "step.launchdarkly_workflow_create",
-            "step.launchdarkly_workflow_delete",
-            "step.launchdarkly_audit_log_list",
-            "step.launchdarkly_audit_log_get",
-            "step.launchdarkly_member_list",
-            "step.launchdarkly_member_get",
-            "step.launchdarkly_member_create",
-            "step.launchdarkly_member_update",
-            "step.launchdarkly_member_delete",
-            "step.launchdarkly_team_list",
-            "step.launchdarkly_team_get",
-            "step.launchdarkly_team_create",
-            "step.launchdarkly_team_update",
-            "step.launchdarkly_team_delete",
-            "step.launchdarkly_role_list",
-            "step.launchdarkly_role_get",
-            "step.launchdarkly_role_create",
-            "step.launchdarkly_role_update",
-            "step.launchdarkly_role_delete",
-            "step.launchdarkly_token_list",
-            "step.launchdarkly_token_get",
-            "step.launchdarkly_token_create",
-            "step.launchdarkly_token_update",
-            "step.launchdarkly_token_delete",
-            "step.launchdarkly_token_reset",
-            "step.launchdarkly_webhook_list",
-            "step.launchdarkly_webhook_get",
-            "step.launchdarkly_webhook_create",
-            "step.launchdarkly_webhook_update",
-            "step.launchdarkly_webhook_delete",
-            "step.launchdarkly_relay_config_list",
-            "step.launchdarkly_relay_config_get",
-            "step.launchdarkly_relay_config_create",
-            "step.launchdarkly_relay_config_update",
-            "step.launchdarkly_relay_config_delete",
-            "step.launchdarkly_release_pipeline_list",
-            "step.launchdarkly_release_pipeline_get",
-            "step.launchdarkly_release_pipeline_create",
-            "step.launchdarkly_release_pipeline_update",
-            "step.launchdarkly_release_pipeline_delete",
-            "step.launchdarkly_code_ref_repo_list",
-            "step.launchdarkly_code_ref_repo_create",
-            "step.launchdarkly_code_ref_repo_delete",
-            "step.launchdarkly_code_ref_extinction_list"
-        ],
-        "triggerTypes": []
+    "stepTypes": [
+      "step.launchdarkly_flag_list",
+      "step.launchdarkly_flag_get",
+      "step.launchdarkly_flag_create",
+      "step.launchdarkly_flag_update",
+      "step.launchdarkly_flag_delete",
+      "step.launchdarkly_flag_copy",
+      "step.launchdarkly_flag_status_get",
+      "step.launchdarkly_flag_status_list",
+      "step.launchdarkly_project_list",
+      "step.launchdarkly_project_get",
+      "step.launchdarkly_project_create",
+      "step.launchdarkly_project_update",
+      "step.launchdarkly_project_delete",
+      "step.launchdarkly_environment_list",
+      "step.launchdarkly_environment_get",
+      "step.launchdarkly_environment_create",
+      "step.launchdarkly_environment_update",
+      "step.launchdarkly_environment_delete",
+      "step.launchdarkly_environment_reset_sdk_key",
+      "step.launchdarkly_environment_reset_mobile_key",
+      "step.launchdarkly_segment_list",
+      "step.launchdarkly_segment_get",
+      "step.launchdarkly_segment_create",
+      "step.launchdarkly_segment_update",
+      "step.launchdarkly_segment_delete",
+      "step.launchdarkly_context_list",
+      "step.launchdarkly_context_get",
+      "step.launchdarkly_context_search",
+      "step.launchdarkly_context_kind_list",
+      "step.launchdarkly_context_kind_upsert",
+      "step.launchdarkly_context_evaluate",
+      "step.launchdarkly_metric_list",
+      "step.launchdarkly_metric_get",
+      "step.launchdarkly_metric_create",
+      "step.launchdarkly_metric_update",
+      "step.launchdarkly_metric_delete",
+      "step.launchdarkly_experiment_list",
+      "step.launchdarkly_experiment_get",
+      "step.launchdarkly_experiment_create",
+      "step.launchdarkly_experiment_update",
+      "step.launchdarkly_experiment_results_get",
+      "step.launchdarkly_approval_list",
+      "step.launchdarkly_approval_get",
+      "step.launchdarkly_approval_create",
+      "step.launchdarkly_approval_delete",
+      "step.launchdarkly_approval_apply",
+      "step.launchdarkly_approval_review",
+      "step.launchdarkly_scheduled_change_list",
+      "step.launchdarkly_scheduled_change_create",
+      "step.launchdarkly_scheduled_change_update",
+      "step.launchdarkly_scheduled_change_delete",
+      "step.launchdarkly_trigger_list",
+      "step.launchdarkly_trigger_create",
+      "step.launchdarkly_trigger_get",
+      "step.launchdarkly_trigger_update",
+      "step.launchdarkly_trigger_delete",
+      "step.launchdarkly_workflow_list",
+      "step.launchdarkly_workflow_get",
+      "step.launchdarkly_workflow_create",
+      "step.launchdarkly_workflow_delete",
+      "step.launchdarkly_audit_log_list",
+      "step.launchdarkly_audit_log_get",
+      "step.launchdarkly_member_list",
+      "step.launchdarkly_member_get",
+      "step.launchdarkly_member_create",
+      "step.launchdarkly_member_update",
+      "step.launchdarkly_member_delete",
+      "step.launchdarkly_team_list",
+      "step.launchdarkly_team_get",
+      "step.launchdarkly_team_create",
+      "step.launchdarkly_team_update",
+      "step.launchdarkly_team_delete",
+      "step.launchdarkly_role_list",
+      "step.launchdarkly_role_get",
+      "step.launchdarkly_role_create",
+      "step.launchdarkly_role_update",
+      "step.launchdarkly_role_delete",
+      "step.launchdarkly_token_list",
+      "step.launchdarkly_token_get",
+      "step.launchdarkly_token_create",
+      "step.launchdarkly_token_update",
+      "step.launchdarkly_token_delete",
+      "step.launchdarkly_token_reset",
+      "step.launchdarkly_webhook_list",
+      "step.launchdarkly_webhook_get",
+      "step.launchdarkly_webhook_create",
+      "step.launchdarkly_webhook_update",
+      "step.launchdarkly_webhook_delete",
+      "step.launchdarkly_relay_config_list",
+      "step.launchdarkly_relay_config_get",
+      "step.launchdarkly_relay_config_create",
+      "step.launchdarkly_relay_config_update",
+      "step.launchdarkly_relay_config_delete",
+      "step.launchdarkly_release_pipeline_list",
+      "step.launchdarkly_release_pipeline_get",
+      "step.launchdarkly_release_pipeline_create",
+      "step.launchdarkly_release_pipeline_update",
+      "step.launchdarkly_release_pipeline_delete",
+      "step.launchdarkly_code_ref_repo_list",
+      "step.launchdarkly_code_ref_repo_create",
+      "step.launchdarkly_code_ref_repo_delete",
+      "step.launchdarkly_code_ref_extinction_list"
+    ],
+    "triggerTypes": []
+  },
+  "stepSchemas": [
+    {
+      "type": "step.launchdarkly_flag_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all feature flags in a LaunchDarkly project",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
     },
-    "stepSchemas": [
-        {
-            "type": "step.launchdarkly_flag_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all feature flags in a LaunchDarkly project",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_flag_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a feature flag by key",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_flag_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a new feature flag",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Flag Name",
-                    "type": "string",
-                    "description": "Human-readable name for the flag",
-                    "required": false
-                },
-                {
-                    "key": "kind",
-                    "label": "Kind",
-                    "type": "string",
-                    "description": "Flag kind: boolean, multivariate (defaults to boolean)",
-                    "required": false,
-                    "defaultValue": "boolean"
-                },
-                {
-                    "key": "description",
-                    "label": "Description",
-                    "type": "string",
-                    "description": "Flag description",
-                    "required": false
-                },
-                {
-                    "key": "tags",
-                    "label": "Tags",
-                    "type": "array",
-                    "description": "Array of tag strings",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_flag_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a feature flag using a JSON patch",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_flag_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a feature flag",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_flag_copy",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Copy feature flag settings from one environment to another",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "sourceEnvironment",
-                    "label": "Source Environment",
-                    "type": "string",
-                    "description": "Source environment key",
-                    "required": true
-                },
-                {
-                    "key": "targetEnvironment",
-                    "label": "Target Environment",
-                    "type": "string",
-                    "description": "Target environment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_flag_status_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get the status of a feature flag in an environment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_flag_status_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List statuses for all feature flags in an environment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_project_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all LaunchDarkly projects",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_project_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a LaunchDarkly project by key",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_project_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a new LaunchDarkly project",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Project Name",
-                    "type": "string",
-                    "description": "Human-readable project name",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_project_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a LaunchDarkly project using a JSON patch",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_project_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a LaunchDarkly project",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_environment_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all environments in a project",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_environment_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get an environment by key",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_environment_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a new environment in a project",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Environment Name",
-                    "type": "string",
-                    "description": "Human-readable environment name",
-                    "required": true
-                },
-                {
-                    "key": "color",
-                    "label": "Color",
-                    "type": "string",
-                    "description": "Environment color hex code (e.g. 417505)",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_environment_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update an environment using a JSON patch",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_environment_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete an environment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_environment_reset_sdk_key",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Reset the SDK key for an environment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_environment_reset_mobile_key",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Reset the mobile key for an environment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_segment_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all segments in a project environment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_segment_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a segment by key",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "segmentKey",
-                    "label": "Segment Key",
-                    "type": "string",
-                    "description": "Segment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_segment_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a new segment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "segmentKey",
-                    "label": "Segment Key",
-                    "type": "string",
-                    "description": "Segment key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Segment Name",
-                    "type": "string",
-                    "description": "Human-readable segment name",
-                    "required": true
-                },
-                {
-                    "key": "description",
-                    "label": "Description",
-                    "type": "string",
-                    "description": "Segment description",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_segment_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a segment using a JSON patch",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "segmentKey",
-                    "label": "Segment Key",
-                    "type": "string",
-                    "description": "Segment key",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_segment_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a segment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "segmentKey",
-                    "label": "Segment Key",
-                    "type": "string",
-                    "description": "Segment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_context_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List contexts in a project environment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_context_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a specific context instance",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "kind",
-                    "label": "Kind",
-                    "type": "string",
-                    "description": "Context kind key",
-                    "required": true
-                },
-                {
-                    "key": "contextKey",
-                    "label": "Context Key",
-                    "type": "string",
-                    "description": "Context key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_context_search",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Search contexts in an environment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "filter",
-                    "label": "Filter",
-                    "type": "string",
-                    "description": "Filter expression",
-                    "required": false
-                },
-                {
-                    "key": "sort",
-                    "label": "Sort",
-                    "type": "string",
-                    "description": "Sort expression",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_context_kind_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List context kinds for a project",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_context_kind_upsert",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create or update a context kind",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "key",
-                    "label": "Key",
-                    "type": "string",
-                    "description": "Context kind key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Name",
-                    "type": "string",
-                    "description": "Context kind display name",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_context_evaluate",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Evaluate feature flags for a context",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "kind",
-                    "label": "Kind",
-                    "type": "string",
-                    "description": "Context kind key",
-                    "required": true
-                },
-                {
-                    "key": "contextKey",
-                    "label": "Context Key",
-                    "type": "string",
-                    "description": "Context key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_metric_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all metrics in a project",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_metric_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a metric by key",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "metricKey",
-                    "label": "Metric Key",
-                    "type": "string",
-                    "description": "Metric key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_metric_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a new metric",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "metricKey",
-                    "label": "Metric Key",
-                    "type": "string",
-                    "description": "Metric key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Metric Name",
-                    "type": "string",
-                    "description": "Human-readable metric name",
-                    "required": true
-                },
-                {
-                    "key": "kind",
-                    "label": "Kind",
-                    "type": "string",
-                    "description": "Metric kind (e.g. pageview, click, custom)",
-                    "required": true
-                },
-                {
-                    "key": "eventKey",
-                    "label": "Event Key",
-                    "type": "string",
-                    "description": "Event key for custom metrics",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_metric_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a metric using a JSON patch",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "metricKey",
-                    "label": "Metric Key",
-                    "type": "string",
-                    "description": "Metric key",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_metric_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a metric",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "metricKey",
-                    "label": "Metric Key",
-                    "type": "string",
-                    "description": "Metric key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_experiment_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all experiments in a project environment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_experiment_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get an experiment by key",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "experimentKey",
-                    "label": "Experiment Key",
-                    "type": "string",
-                    "description": "Experiment key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_experiment_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a new experiment",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Experiment Name",
-                    "type": "string",
-                    "description": "Experiment name",
-                    "required": true
-                },
-                {
-                    "key": "description",
-                    "label": "Description",
-                    "type": "string",
-                    "description": "Experiment description",
-                    "required": false
-                },
-                {
-                    "key": "iteration",
-                    "label": "Iteration",
-                    "type": "json",
-                    "description": "Iteration configuration",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_experiment_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update an experiment using a JSON patch",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "experimentKey",
-                    "label": "Experiment Key",
-                    "type": "string",
-                    "description": "Experiment key",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_experiment_results_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get experiment results for a metric",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "experimentKey",
-                    "label": "Experiment Key",
-                    "type": "string",
-                    "description": "Experiment key",
-                    "required": true
-                },
-                {
-                    "key": "metricKey",
-                    "label": "Metric Key",
-                    "type": "string",
-                    "description": "Metric key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_approval_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all approval requests",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_approval_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get an approval request by ID",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "approvalId",
-                    "label": "Approval ID",
-                    "type": "string",
-                    "description": "Approval request ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_approval_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create an approval request",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "description",
-                    "label": "Description",
-                    "type": "string",
-                    "description": "Approval request description",
-                    "required": true
-                },
-                {
-                    "key": "instructions",
-                    "label": "Instructions",
-                    "type": "json",
-                    "description": "Semantic patch instructions",
-                    "required": false
-                },
-                {
-                    "key": "notifyMemberIds",
-                    "label": "Notify Members",
-                    "type": "array",
-                    "description": "Member IDs to notify",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_approval_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete an approval request",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "approvalId",
-                    "label": "Approval ID",
-                    "type": "string",
-                    "description": "Approval request ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_approval_apply",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Apply an approval request",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "approvalId",
-                    "label": "Approval ID",
-                    "type": "string",
-                    "description": "Approval request ID",
-                    "required": true
-                },
-                {
-                    "key": "comment",
-                    "label": "Comment",
-                    "type": "string",
-                    "description": "Optional comment",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_approval_review",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Review an approval request",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "approvalId",
-                    "label": "Approval ID",
-                    "type": "string",
-                    "description": "Approval request ID",
-                    "required": true
-                },
-                {
-                    "key": "kind",
-                    "label": "Kind",
-                    "type": "string",
-                    "description": "Review kind: approve or decline",
-                    "required": true
-                },
-                {
-                    "key": "comment",
-                    "label": "Comment",
-                    "type": "string",
-                    "description": "Optional review comment",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_scheduled_change_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List scheduled changes for a feature flag",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_scheduled_change_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a scheduled change for a feature flag",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "executionDate",
-                    "label": "Execution Date",
-                    "type": "number",
-                    "description": "Scheduled execution date/time (ms epoch)",
-                    "required": true
-                },
-                {
-                    "key": "instructions",
-                    "label": "Instructions",
-                    "type": "json",
-                    "description": "Semantic patch instructions",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_scheduled_change_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a scheduled change",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "scheduledChangeId",
-                    "label": "Scheduled Change ID",
-                    "type": "string",
-                    "description": "Scheduled change ID",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_scheduled_change_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a scheduled change",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "scheduledChangeId",
-                    "label": "Scheduled Change ID",
-                    "type": "string",
-                    "description": "Scheduled change ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_trigger_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List flag triggers for a feature flag",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_trigger_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a flag trigger",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "integrationKey",
-                    "label": "Integration Key",
-                    "type": "string",
-                    "description": "Integration key for the trigger",
-                    "required": true
-                },
-                {
-                    "key": "instructions",
-                    "label": "Instructions",
-                    "type": "json",
-                    "description": "Semantic patch instructions",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_trigger_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a flag trigger by ID",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "triggerId",
-                    "label": "Trigger ID",
-                    "type": "string",
-                    "description": "Trigger ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_trigger_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a flag trigger",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "triggerId",
-                    "label": "Trigger ID",
-                    "type": "string",
-                    "description": "Trigger ID",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_trigger_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a flag trigger",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "triggerId",
-                    "label": "Trigger ID",
-                    "type": "string",
-                    "description": "Trigger ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_workflow_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List workflows for a feature flag",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_workflow_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a workflow by ID",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "workflowId",
-                    "label": "Workflow ID",
-                    "type": "string",
-                    "description": "Workflow ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_workflow_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a workflow for a feature flag",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Workflow Name",
-                    "type": "string",
-                    "description": "Workflow name",
-                    "required": true
-                },
-                {
-                    "key": "stages",
-                    "label": "Stages",
-                    "type": "json",
-                    "description": "Workflow stages configuration",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_workflow_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a workflow",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "environmentKey",
-                    "label": "Environment Key",
-                    "type": "string",
-                    "description": "LaunchDarkly environment key",
-                    "required": true
-                },
-                {
-                    "key": "flagKey",
-                    "label": "Flag Key",
-                    "type": "string",
-                    "description": "Feature flag key",
-                    "required": true
-                },
-                {
-                    "key": "workflowId",
-                    "label": "Workflow ID",
-                    "type": "string",
-                    "description": "Workflow ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_audit_log_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List audit log entries",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_audit_log_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get an audit log entry by ID",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "specId",
-                    "label": "Spec ID",
-                    "type": "string",
-                    "description": "Audit log entry spec ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_member_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all team members",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_member_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a team member by ID",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "memberId",
-                    "label": "Member ID",
-                    "type": "string",
-                    "description": "Member ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_member_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Invite a new team member",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "email",
-                    "label": "Email",
-                    "type": "string",
-                    "description": "Member email address",
-                    "required": true
-                },
-                {
-                    "key": "role",
-                    "label": "Role",
-                    "type": "string",
-                    "description": "Member role (reader, writer, admin, no_access)",
-                    "required": false
-                },
-                {
-                    "key": "firstName",
-                    "label": "First Name",
-                    "type": "string",
-                    "description": "Member first name",
-                    "required": false
-                },
-                {
-                    "key": "lastName",
-                    "label": "Last Name",
-                    "type": "string",
-                    "description": "Member last name",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_member_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a team member",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "memberId",
-                    "label": "Member ID",
-                    "type": "string",
-                    "description": "Member ID",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_member_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Remove a team member",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "memberId",
-                    "label": "Member ID",
-                    "type": "string",
-                    "description": "Member ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_team_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all teams",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_team_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a team by key",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "teamKey",
-                    "label": "Team Key",
-                    "type": "string",
-                    "description": "Team key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_team_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a new team",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "teamKey",
-                    "label": "Team Key",
-                    "type": "string",
-                    "description": "Team key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Team Name",
-                    "type": "string",
-                    "description": "Team name",
-                    "required": true
-                },
-                {
-                    "key": "description",
-                    "label": "Description",
-                    "type": "string",
-                    "description": "Team description",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_team_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a team",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "teamKey",
-                    "label": "Team Key",
-                    "type": "string",
-                    "description": "Team key",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_team_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a team",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "teamKey",
-                    "label": "Team Key",
-                    "type": "string",
-                    "description": "Team key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_role_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all custom roles",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_role_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a custom role by key",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "customRoleKey",
-                    "label": "Custom Role Key",
-                    "type": "string",
-                    "description": "Custom role key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_role_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a custom role",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "key",
-                    "label": "Key",
-                    "type": "string",
-                    "description": "Custom role key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Name",
-                    "type": "string",
-                    "description": "Custom role name",
-                    "required": true
-                },
-                {
-                    "key": "description",
-                    "label": "Description",
-                    "type": "string",
-                    "description": "Custom role description",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_role_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a custom role",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "customRoleKey",
-                    "label": "Custom Role Key",
-                    "type": "string",
-                    "description": "Custom role key",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_role_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a custom role",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "customRoleKey",
-                    "label": "Custom Role Key",
-                    "type": "string",
-                    "description": "Custom role key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_token_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all access tokens",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_token_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get an access token by ID",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "tokenId",
-                    "label": "Token ID",
-                    "type": "string",
-                    "description": "Access token ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_token_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a new access token",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "name",
-                    "label": "Name",
-                    "type": "string",
-                    "description": "Token name",
-                    "required": false
-                },
-                {
-                    "key": "role",
-                    "label": "Role",
-                    "type": "string",
-                    "description": "Built-in role for the token",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_token_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update an access token",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "tokenId",
-                    "label": "Token ID",
-                    "type": "string",
-                    "description": "Access token ID",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_token_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete an access token",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "tokenId",
-                    "label": "Token ID",
-                    "type": "string",
-                    "description": "Access token ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_token_reset",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Reset an access token",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "tokenId",
-                    "label": "Token ID",
-                    "type": "string",
-                    "description": "Access token ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_webhook_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List all webhooks",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_webhook_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a webhook by ID",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "webhookId",
-                    "label": "Webhook ID",
-                    "type": "string",
-                    "description": "Webhook ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_webhook_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a new webhook",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "url",
-                    "label": "URL",
-                    "type": "string",
-                    "description": "Webhook URL",
-                    "required": true
-                },
-                {
-                    "key": "sign",
-                    "label": "Sign",
-                    "type": "boolean",
-                    "description": "Whether to sign the webhook",
-                    "required": false
-                },
-                {
-                    "key": "on",
-                    "label": "On",
-                    "type": "boolean",
-                    "description": "Whether the webhook is enabled",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_webhook_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a webhook",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "webhookId",
-                    "label": "Webhook ID",
-                    "type": "string",
-                    "description": "Webhook ID",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_webhook_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a webhook",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "webhookId",
-                    "label": "Webhook ID",
-                    "type": "string",
-                    "description": "Webhook ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_relay_config_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List Relay Proxy configurations",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_relay_config_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a Relay Proxy configuration by ID",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "relayId",
-                    "label": "Relay Config ID",
-                    "type": "string",
-                    "description": "Relay Proxy configuration ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_relay_config_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a Relay Proxy configuration",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "name",
-                    "label": "Name",
-                    "type": "string",
-                    "description": "Relay Proxy configuration name",
-                    "required": true
-                },
-                {
-                    "key": "policy",
-                    "label": "Policy",
-                    "type": "json",
-                    "description": "Policy configuration",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_relay_config_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a Relay Proxy configuration",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "relayId",
-                    "label": "Relay Config ID",
-                    "type": "string",
-                    "description": "Relay Proxy configuration ID",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_relay_config_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a Relay Proxy configuration",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "relayId",
-                    "label": "Relay Config ID",
-                    "type": "string",
-                    "description": "Relay Proxy configuration ID",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_release_pipeline_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List release pipelines for a project",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                },
-                {
-                    "key": "totalCount",
-                    "type": "number",
-                    "description": "Total count of items"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_release_pipeline_get",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Get a release pipeline by key",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "pipelineKey",
-                    "label": "Pipeline Key",
-                    "type": "string",
-                    "description": "Release pipeline key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_release_pipeline_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create a release pipeline",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "key",
-                    "label": "Key",
-                    "type": "string",
-                    "description": "Release pipeline key",
-                    "required": true
-                },
-                {
-                    "key": "name",
-                    "label": "Name",
-                    "type": "string",
-                    "description": "Release pipeline name",
-                    "required": true
-                },
-                {
-                    "key": "description",
-                    "label": "Description",
-                    "type": "string",
-                    "description": "Release pipeline description",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_release_pipeline_update",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Update a release pipeline",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "pipelineKey",
-                    "label": "Pipeline Key",
-                    "type": "string",
-                    "description": "Release pipeline key",
-                    "required": true
-                },
-                {
-                    "key": "patch",
-                    "label": "Patch",
-                    "type": "json",
-                    "description": "JSON patch document to apply",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_release_pipeline_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a release pipeline",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "projectKey",
-                    "label": "Project Key",
-                    "type": "string",
-                    "description": "LaunchDarkly project key",
-                    "required": true
-                },
-                {
-                    "key": "pipelineKey",
-                    "label": "Pipeline Key",
-                    "type": "string",
-                    "description": "Release pipeline key",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_code_ref_repo_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List code reference repositories",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_code_ref_repo_create",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Create or update a code reference repository",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "name",
-                    "label": "Repository Name",
-                    "type": "string",
-                    "description": "Repository name",
-                    "required": true
-                },
-                {
-                    "key": "sourceLink",
-                    "label": "Source Link",
-                    "type": "string",
-                    "description": "URL to repository source",
-                    "required": false
-                },
-                {
-                    "key": "commitUrlTemplate",
-                    "label": "Commit URL Template",
-                    "type": "string",
-                    "description": "URL template for commits",
-                    "required": false
-                },
-                {
-                    "key": "hunkUrlTemplate",
-                    "label": "Hunk URL Template",
-                    "type": "string",
-                    "description": "URL template for code hunks",
-                    "required": false
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_code_ref_repo_delete",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "Delete a code reference repository",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "name",
-                    "label": "Repository Name",
-                    "type": "string",
-                    "description": "Repository name",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                }
-            ]
-        },
-        {
-            "type": "step.launchdarkly_code_ref_extinction_list",
-            "plugin": "workflow-plugin-launchdarkly",
-            "description": "List extinctions for a code reference repository",
-            "configFields": [
-                {
-                    "key": "module",
-                    "label": "Module",
-                    "type": "string",
-                    "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
-                    "required": false,
-                    "defaultValue": "launchdarkly"
-                },
-                {
-                    "key": "repoName",
-                    "label": "Repository Name",
-                    "type": "string",
-                    "description": "Repository name",
-                    "required": true
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the request failed"
-                },
-                {
-                    "key": "items",
-                    "type": "array",
-                    "description": "List of items returned"
-                }
-            ]
+    {
+      "type": "step.launchdarkly_flag_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a feature flag by key",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
         }
-    ],
-    "downloads": [
+      ],
+      "outputs": [
         {
-            "os": "linux",
-            "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_linux_amd64.tar.gz"
-        },
-        {
-            "os": "linux",
-            "arch": "arm64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_linux_arm64.tar.gz"
-        },
-        {
-            "os": "darwin",
-            "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_darwin_amd64.tar.gz"
-        },
-        {
-            "os": "darwin",
-            "arch": "arm64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_darwin_arm64.tar.gz"
-        },
-        {
-            "os": "windows",
-            "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_windows_amd64.zip"
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
         }
-    ]
+      ]
+    },
+    {
+      "type": "step.launchdarkly_flag_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a new feature flag",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Flag Name",
+          "type": "string",
+          "description": "Human-readable name for the flag",
+          "required": false
+        },
+        {
+          "key": "kind",
+          "label": "Kind",
+          "type": "string",
+          "description": "Flag kind: boolean, multivariate (defaults to boolean)",
+          "required": false,
+          "defaultValue": "boolean"
+        },
+        {
+          "key": "description",
+          "label": "Description",
+          "type": "string",
+          "description": "Flag description",
+          "required": false
+        },
+        {
+          "key": "tags",
+          "label": "Tags",
+          "type": "array",
+          "description": "Array of tag strings",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_flag_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a feature flag using a JSON patch",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_flag_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a feature flag",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_flag_copy",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Copy feature flag settings from one environment to another",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "sourceEnvironment",
+          "label": "Source Environment",
+          "type": "string",
+          "description": "Source environment key",
+          "required": true
+        },
+        {
+          "key": "targetEnvironment",
+          "label": "Target Environment",
+          "type": "string",
+          "description": "Target environment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_flag_status_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get the status of a feature flag in an environment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_flag_status_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List statuses for all feature flags in an environment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_project_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all LaunchDarkly projects",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_project_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a LaunchDarkly project by key",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_project_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a new LaunchDarkly project",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Project Name",
+          "type": "string",
+          "description": "Human-readable project name",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_project_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a LaunchDarkly project using a JSON patch",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_project_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a LaunchDarkly project",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_environment_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all environments in a project",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_environment_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get an environment by key",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_environment_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a new environment in a project",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Environment Name",
+          "type": "string",
+          "description": "Human-readable environment name",
+          "required": true
+        },
+        {
+          "key": "color",
+          "label": "Color",
+          "type": "string",
+          "description": "Environment color hex code (e.g. 417505)",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_environment_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update an environment using a JSON patch",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_environment_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete an environment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_environment_reset_sdk_key",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Reset the SDK key for an environment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_environment_reset_mobile_key",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Reset the mobile key for an environment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_segment_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all segments in a project environment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_segment_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a segment by key",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "segmentKey",
+          "label": "Segment Key",
+          "type": "string",
+          "description": "Segment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_segment_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a new segment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "segmentKey",
+          "label": "Segment Key",
+          "type": "string",
+          "description": "Segment key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Segment Name",
+          "type": "string",
+          "description": "Human-readable segment name",
+          "required": true
+        },
+        {
+          "key": "description",
+          "label": "Description",
+          "type": "string",
+          "description": "Segment description",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_segment_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a segment using a JSON patch",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "segmentKey",
+          "label": "Segment Key",
+          "type": "string",
+          "description": "Segment key",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_segment_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a segment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "segmentKey",
+          "label": "Segment Key",
+          "type": "string",
+          "description": "Segment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_context_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List contexts in a project environment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_context_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a specific context instance",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "kind",
+          "label": "Kind",
+          "type": "string",
+          "description": "Context kind key",
+          "required": true
+        },
+        {
+          "key": "contextKey",
+          "label": "Context Key",
+          "type": "string",
+          "description": "Context key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_context_search",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Search contexts in an environment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "filter",
+          "label": "Filter",
+          "type": "string",
+          "description": "Filter expression",
+          "required": false
+        },
+        {
+          "key": "sort",
+          "label": "Sort",
+          "type": "string",
+          "description": "Sort expression",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_context_kind_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List context kinds for a project",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_context_kind_upsert",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create or update a context kind",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "key",
+          "label": "Key",
+          "type": "string",
+          "description": "Context kind key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Name",
+          "type": "string",
+          "description": "Context kind display name",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_context_evaluate",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Evaluate feature flags for a context",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "kind",
+          "label": "Kind",
+          "type": "string",
+          "description": "Context kind key",
+          "required": true
+        },
+        {
+          "key": "contextKey",
+          "label": "Context Key",
+          "type": "string",
+          "description": "Context key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_metric_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all metrics in a project",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_metric_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a metric by key",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "metricKey",
+          "label": "Metric Key",
+          "type": "string",
+          "description": "Metric key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_metric_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a new metric",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "metricKey",
+          "label": "Metric Key",
+          "type": "string",
+          "description": "Metric key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Metric Name",
+          "type": "string",
+          "description": "Human-readable metric name",
+          "required": true
+        },
+        {
+          "key": "kind",
+          "label": "Kind",
+          "type": "string",
+          "description": "Metric kind (e.g. pageview, click, custom)",
+          "required": true
+        },
+        {
+          "key": "eventKey",
+          "label": "Event Key",
+          "type": "string",
+          "description": "Event key for custom metrics",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_metric_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a metric using a JSON patch",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "metricKey",
+          "label": "Metric Key",
+          "type": "string",
+          "description": "Metric key",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_metric_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a metric",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "metricKey",
+          "label": "Metric Key",
+          "type": "string",
+          "description": "Metric key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_experiment_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all experiments in a project environment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_experiment_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get an experiment by key",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "experimentKey",
+          "label": "Experiment Key",
+          "type": "string",
+          "description": "Experiment key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_experiment_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a new experiment",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Experiment Name",
+          "type": "string",
+          "description": "Experiment name",
+          "required": true
+        },
+        {
+          "key": "description",
+          "label": "Description",
+          "type": "string",
+          "description": "Experiment description",
+          "required": false
+        },
+        {
+          "key": "iteration",
+          "label": "Iteration",
+          "type": "json",
+          "description": "Iteration configuration",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_experiment_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update an experiment using a JSON patch",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "experimentKey",
+          "label": "Experiment Key",
+          "type": "string",
+          "description": "Experiment key",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_experiment_results_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get experiment results for a metric",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "experimentKey",
+          "label": "Experiment Key",
+          "type": "string",
+          "description": "Experiment key",
+          "required": true
+        },
+        {
+          "key": "metricKey",
+          "label": "Metric Key",
+          "type": "string",
+          "description": "Metric key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_approval_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all approval requests",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_approval_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get an approval request by ID",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "approvalId",
+          "label": "Approval ID",
+          "type": "string",
+          "description": "Approval request ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_approval_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create an approval request",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "description",
+          "label": "Description",
+          "type": "string",
+          "description": "Approval request description",
+          "required": true
+        },
+        {
+          "key": "instructions",
+          "label": "Instructions",
+          "type": "json",
+          "description": "Semantic patch instructions",
+          "required": false
+        },
+        {
+          "key": "notifyMemberIds",
+          "label": "Notify Members",
+          "type": "array",
+          "description": "Member IDs to notify",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_approval_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete an approval request",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "approvalId",
+          "label": "Approval ID",
+          "type": "string",
+          "description": "Approval request ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_approval_apply",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Apply an approval request",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "approvalId",
+          "label": "Approval ID",
+          "type": "string",
+          "description": "Approval request ID",
+          "required": true
+        },
+        {
+          "key": "comment",
+          "label": "Comment",
+          "type": "string",
+          "description": "Optional comment",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_approval_review",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Review an approval request",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "approvalId",
+          "label": "Approval ID",
+          "type": "string",
+          "description": "Approval request ID",
+          "required": true
+        },
+        {
+          "key": "kind",
+          "label": "Kind",
+          "type": "string",
+          "description": "Review kind: approve or decline",
+          "required": true
+        },
+        {
+          "key": "comment",
+          "label": "Comment",
+          "type": "string",
+          "description": "Optional review comment",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_scheduled_change_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List scheduled changes for a feature flag",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_scheduled_change_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a scheduled change for a feature flag",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "executionDate",
+          "label": "Execution Date",
+          "type": "number",
+          "description": "Scheduled execution date/time (ms epoch)",
+          "required": true
+        },
+        {
+          "key": "instructions",
+          "label": "Instructions",
+          "type": "json",
+          "description": "Semantic patch instructions",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_scheduled_change_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a scheduled change",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "scheduledChangeId",
+          "label": "Scheduled Change ID",
+          "type": "string",
+          "description": "Scheduled change ID",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_scheduled_change_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a scheduled change",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "scheduledChangeId",
+          "label": "Scheduled Change ID",
+          "type": "string",
+          "description": "Scheduled change ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_trigger_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List flag triggers for a feature flag",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_trigger_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a flag trigger",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "integrationKey",
+          "label": "Integration Key",
+          "type": "string",
+          "description": "Integration key for the trigger",
+          "required": true
+        },
+        {
+          "key": "instructions",
+          "label": "Instructions",
+          "type": "json",
+          "description": "Semantic patch instructions",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_trigger_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a flag trigger by ID",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "triggerId",
+          "label": "Trigger ID",
+          "type": "string",
+          "description": "Trigger ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_trigger_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a flag trigger",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "triggerId",
+          "label": "Trigger ID",
+          "type": "string",
+          "description": "Trigger ID",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_trigger_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a flag trigger",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "triggerId",
+          "label": "Trigger ID",
+          "type": "string",
+          "description": "Trigger ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_workflow_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List workflows for a feature flag",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_workflow_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a workflow by ID",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "workflowId",
+          "label": "Workflow ID",
+          "type": "string",
+          "description": "Workflow ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_workflow_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a workflow for a feature flag",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Workflow Name",
+          "type": "string",
+          "description": "Workflow name",
+          "required": true
+        },
+        {
+          "key": "stages",
+          "label": "Stages",
+          "type": "json",
+          "description": "Workflow stages configuration",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_workflow_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a workflow",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "environmentKey",
+          "label": "Environment Key",
+          "type": "string",
+          "description": "LaunchDarkly environment key",
+          "required": true
+        },
+        {
+          "key": "flagKey",
+          "label": "Flag Key",
+          "type": "string",
+          "description": "Feature flag key",
+          "required": true
+        },
+        {
+          "key": "workflowId",
+          "label": "Workflow ID",
+          "type": "string",
+          "description": "Workflow ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_audit_log_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List audit log entries",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_audit_log_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get an audit log entry by ID",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "specId",
+          "label": "Spec ID",
+          "type": "string",
+          "description": "Audit log entry spec ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_member_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all team members",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_member_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a team member by ID",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "memberId",
+          "label": "Member ID",
+          "type": "string",
+          "description": "Member ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_member_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Invite a new team member",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "email",
+          "label": "Email",
+          "type": "string",
+          "description": "Member email address",
+          "required": true
+        },
+        {
+          "key": "role",
+          "label": "Role",
+          "type": "string",
+          "description": "Member role (reader, writer, admin, no_access)",
+          "required": false
+        },
+        {
+          "key": "firstName",
+          "label": "First Name",
+          "type": "string",
+          "description": "Member first name",
+          "required": false
+        },
+        {
+          "key": "lastName",
+          "label": "Last Name",
+          "type": "string",
+          "description": "Member last name",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_member_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a team member",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "memberId",
+          "label": "Member ID",
+          "type": "string",
+          "description": "Member ID",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_member_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Remove a team member",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "memberId",
+          "label": "Member ID",
+          "type": "string",
+          "description": "Member ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_team_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all teams",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_team_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a team by key",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "teamKey",
+          "label": "Team Key",
+          "type": "string",
+          "description": "Team key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_team_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a new team",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "teamKey",
+          "label": "Team Key",
+          "type": "string",
+          "description": "Team key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Team Name",
+          "type": "string",
+          "description": "Team name",
+          "required": true
+        },
+        {
+          "key": "description",
+          "label": "Description",
+          "type": "string",
+          "description": "Team description",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_team_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a team",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "teamKey",
+          "label": "Team Key",
+          "type": "string",
+          "description": "Team key",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_team_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a team",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "teamKey",
+          "label": "Team Key",
+          "type": "string",
+          "description": "Team key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_role_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all custom roles",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_role_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a custom role by key",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "customRoleKey",
+          "label": "Custom Role Key",
+          "type": "string",
+          "description": "Custom role key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_role_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a custom role",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "key",
+          "label": "Key",
+          "type": "string",
+          "description": "Custom role key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Name",
+          "type": "string",
+          "description": "Custom role name",
+          "required": true
+        },
+        {
+          "key": "description",
+          "label": "Description",
+          "type": "string",
+          "description": "Custom role description",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_role_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a custom role",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "customRoleKey",
+          "label": "Custom Role Key",
+          "type": "string",
+          "description": "Custom role key",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_role_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a custom role",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "customRoleKey",
+          "label": "Custom Role Key",
+          "type": "string",
+          "description": "Custom role key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_token_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all access tokens",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_token_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get an access token by ID",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "tokenId",
+          "label": "Token ID",
+          "type": "string",
+          "description": "Access token ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_token_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a new access token",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "name",
+          "label": "Name",
+          "type": "string",
+          "description": "Token name",
+          "required": false
+        },
+        {
+          "key": "role",
+          "label": "Role",
+          "type": "string",
+          "description": "Built-in role for the token",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_token_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update an access token",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "tokenId",
+          "label": "Token ID",
+          "type": "string",
+          "description": "Access token ID",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_token_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete an access token",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "tokenId",
+          "label": "Token ID",
+          "type": "string",
+          "description": "Access token ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_token_reset",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Reset an access token",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "tokenId",
+          "label": "Token ID",
+          "type": "string",
+          "description": "Access token ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_webhook_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List all webhooks",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_webhook_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a webhook by ID",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "webhookId",
+          "label": "Webhook ID",
+          "type": "string",
+          "description": "Webhook ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_webhook_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a new webhook",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "url",
+          "label": "URL",
+          "type": "string",
+          "description": "Webhook URL",
+          "required": true
+        },
+        {
+          "key": "sign",
+          "label": "Sign",
+          "type": "boolean",
+          "description": "Whether to sign the webhook",
+          "required": false
+        },
+        {
+          "key": "on",
+          "label": "On",
+          "type": "boolean",
+          "description": "Whether the webhook is enabled",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_webhook_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a webhook",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "webhookId",
+          "label": "Webhook ID",
+          "type": "string",
+          "description": "Webhook ID",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_webhook_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a webhook",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "webhookId",
+          "label": "Webhook ID",
+          "type": "string",
+          "description": "Webhook ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_relay_config_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List Relay Proxy configurations",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_relay_config_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a Relay Proxy configuration by ID",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "relayId",
+          "label": "Relay Config ID",
+          "type": "string",
+          "description": "Relay Proxy configuration ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_relay_config_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a Relay Proxy configuration",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "name",
+          "label": "Name",
+          "type": "string",
+          "description": "Relay Proxy configuration name",
+          "required": true
+        },
+        {
+          "key": "policy",
+          "label": "Policy",
+          "type": "json",
+          "description": "Policy configuration",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_relay_config_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a Relay Proxy configuration",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "relayId",
+          "label": "Relay Config ID",
+          "type": "string",
+          "description": "Relay Proxy configuration ID",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_relay_config_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a Relay Proxy configuration",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "relayId",
+          "label": "Relay Config ID",
+          "type": "string",
+          "description": "Relay Proxy configuration ID",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_release_pipeline_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List release pipelines for a project",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        },
+        {
+          "key": "totalCount",
+          "type": "number",
+          "description": "Total count of items"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_release_pipeline_get",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Get a release pipeline by key",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "pipelineKey",
+          "label": "Pipeline Key",
+          "type": "string",
+          "description": "Release pipeline key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_release_pipeline_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create a release pipeline",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "key",
+          "label": "Key",
+          "type": "string",
+          "description": "Release pipeline key",
+          "required": true
+        },
+        {
+          "key": "name",
+          "label": "Name",
+          "type": "string",
+          "description": "Release pipeline name",
+          "required": true
+        },
+        {
+          "key": "description",
+          "label": "Description",
+          "type": "string",
+          "description": "Release pipeline description",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_release_pipeline_update",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Update a release pipeline",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "pipelineKey",
+          "label": "Pipeline Key",
+          "type": "string",
+          "description": "Release pipeline key",
+          "required": true
+        },
+        {
+          "key": "patch",
+          "label": "Patch",
+          "type": "json",
+          "description": "JSON patch document to apply",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_release_pipeline_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a release pipeline",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "projectKey",
+          "label": "Project Key",
+          "type": "string",
+          "description": "LaunchDarkly project key",
+          "required": true
+        },
+        {
+          "key": "pipelineKey",
+          "label": "Pipeline Key",
+          "type": "string",
+          "description": "Release pipeline key",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_code_ref_repo_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List code reference repositories",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_code_ref_repo_create",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Create or update a code reference repository",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "name",
+          "label": "Repository Name",
+          "type": "string",
+          "description": "Repository name",
+          "required": true
+        },
+        {
+          "key": "sourceLink",
+          "label": "Source Link",
+          "type": "string",
+          "description": "URL to repository source",
+          "required": false
+        },
+        {
+          "key": "commitUrlTemplate",
+          "label": "Commit URL Template",
+          "type": "string",
+          "description": "URL template for commits",
+          "required": false
+        },
+        {
+          "key": "hunkUrlTemplate",
+          "label": "Hunk URL Template",
+          "type": "string",
+          "description": "URL template for code hunks",
+          "required": false
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_code_ref_repo_delete",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "Delete a code reference repository",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "name",
+          "label": "Repository Name",
+          "type": "string",
+          "description": "Repository name",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        }
+      ]
+    },
+    {
+      "type": "step.launchdarkly_code_ref_extinction_list",
+      "plugin": "workflow-plugin-launchdarkly",
+      "description": "List extinctions for a code reference repository",
+      "configFields": [
+        {
+          "key": "module",
+          "label": "Module",
+          "type": "string",
+          "description": "LaunchDarkly provider module name (defaults to 'launchdarkly')",
+          "required": false,
+          "defaultValue": "launchdarkly"
+        },
+        {
+          "key": "repoName",
+          "label": "Repository Name",
+          "type": "string",
+          "description": "Repository name",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the request failed"
+        },
+        {
+          "key": "items",
+          "type": "array",
+          "description": "List of items returned"
+        }
+      ]
+    }
+  ],
+  "downloads": [
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_linux_amd64.tar.gz"
+    },
+    {
+      "os": "linux",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_linux_arm64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_darwin_amd64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_darwin_arm64.tar.gz"
+    },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly_windows_amd64.zip"
+    }
+  ]
 }


### PR DESCRIPTION
Advertise required_secrets[] so 'wfctl secrets setup --plugin launchdarkly' provisions credentials uniformly. Part of the ecosystem sweep (workspace docs/plans/2026-05-31-plugin-required-secrets-sweep*; ADR 0006). No release. Names per design §4 (MED-confidence convention-set, scoped descriptions). Copilot not requested (down).