### PR TITLE
ci: canonical registry notify (fix dead dispatch + drop manifest-overwrite)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,23 @@ jobs:
           fi
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
 
+  publish-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish GitHub release
+        if: ${{ success() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
+
   notify-workflow-registry:
     name: Notify workflow-registry
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: release
+    needs: publish-release
     if: >-
       !github.event.deleted
       && !contains(github.ref_name, '-')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,43 +49,23 @@ jobs:
             exit 0
           fi
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
-      - name: Sync manifest to registry
-        if: success() && env.GH_TOKEN != ''
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-        run: |
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/GoCodeAlone/workflow-registry.git" /tmp/registry
-          mkdir -p /tmp/registry/plugins/launchdarkly
-          TAG=${GITHUB_REF#refs/tags/}
-          VERSION=${TAG#v}
-          jq --arg v "$VERSION" '.version = $v' plugin.json > /tmp/registry/plugins/launchdarkly/manifest.json
-          cd /tmp/registry
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add plugins/launchdarkly/manifest.json
-          git diff --cached --quiet || git commit -m "chore: sync launchdarkly plugin manifest v${VERSION}"
-          git push
 
-  notify-registry:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [release]
+  notify-workflow-registry:
+    name: Notify workflow-registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: release
+    if: >-
+      !github.event.deleted
+      && !contains(github.ref_name, '-')
+      && github.repository == 'GoCodeAlone/workflow-plugin-launchdarkly'
     steps:
-      - name: Notify workflow-registry
-        if: env.GH_TOKEN != ''
-        uses: peter-evans/repository-dispatch@v3
+      - name: Trigger registry manifest sync
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
         with:
-          token: ${{ secrets.REGISTRY_PAT }}
+          token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry
           event-type: plugin-release
-          client-payload: >-
-            {"plugin": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}
-        env:
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-        continue-on-error: true
-      - name: Publish GitHub release
-        if: ${{ success() }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
+          client-payload: |-
+            {"plugin": "launchdarkly", "tag": "${{ github.ref_name }}"}


### PR DESCRIPTION
Switch from broken dual-notify pattern to fleet-canonical registry dispatch.

**Removed:**
- Direct manifest-write step: cloned workflow-registry and wrote `plugins/launchdarkly/manifest.json` via `jq` — registry owns its own manifests; direct writes bypass sync logic and cause conflicts.
- `notify-registry` job: used dead `REGISTRY_PAT` secret and full `github.repository` as plugin name (registry expects bare name `launchdarkly`); used unpinned `peter-evans/repository-dispatch@v3`.

**Added:**
- `notify-workflow-registry` job: pinned SHA `peter-evans/repository-dispatch@28959ce...` (v4), `repo_dispatch_token` secret, bare name payload `{"plugin": "launchdarkly", "tag": "..."}`, pre-release guard (`!contains(ref_name, '-')`), `needs: release`.